### PR TITLE
fix Linux compiler - fatal error

### DIFF
--- a/arm9/source/main.c
+++ b/arm9/source/main.c
@@ -41,8 +41,8 @@
 #include "frontend.h"
 
 #include "main.h"
-#include "disk\diskstr.h"
-#include "mpu\pu.h" //use MPU + DTCM
+#include "disk/diskstr.h"
+#include "mpu/pu.h" //use MPU + DTCM
 
 #include "font_8x8_uv.h"
 


### PR DESCRIPTION
Fix SnemulDS/arm9/source/main.c:45:37: fatal error: mpu\pu.h: No such file or directory;
Fix SnemulDS/arm9/source/main.c:44:26: fatal error: disk\diskstr.h: No such file or directory
Fix SnemulDS/arm9/source/mpu/pu.c:17:21: fatal error: ..\main.h: No such file or directory